### PR TITLE
Run npm ci before deploying

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -46,4 +46,5 @@ jobs:
         with:
           node-version: 16.x
 
+      - run: npm ci
       - run: npm run deploy


### PR DESCRIPTION
Creating a PR to confirm the deploy step doesn't run until the PR is merged.