### PR TITLE
Bump @testing-library/react from 12.1.4 to 13.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.3",
-        "@testing-library/react": "^12.1.4",
+        "@testing-library/react": "^13.0.0",
         "@testing-library/user-event": "^14.0.4",
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.23",
@@ -3347,20 +3347,20 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.4.tgz",
-      "integrity": "sha512-jiPKOm7vyUw311Hn/HlNQ9P8/lHNtArAx0PisXyFixDDvfl8DbD6EUdbshK5eqauvBSvzZd19itqQ9j3nferJA==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.0.0.tgz",
+      "integrity": "sha512-p0lYA1M7uoEmk2LnCbZLGmHJHyH59sAaZVXChTXlyhV/PRW9LoIh4mdf7tiXsO8BoNG+vN8UnFJff1hbZeXv+w==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^8.0.0",
+        "@testing-library/dom": "^8.5.0",
         "@types/react-dom": "*"
       },
       "engines": {
         "node": ">=12"
       },
       "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@testing-library/user-event": {
@@ -18500,12 +18500,12 @@
       }
     },
     "@testing-library/react": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.4.tgz",
-      "integrity": "sha512-jiPKOm7vyUw311Hn/HlNQ9P8/lHNtArAx0PisXyFixDDvfl8DbD6EUdbshK5eqauvBSvzZd19itqQ9j3nferJA==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.0.0.tgz",
+      "integrity": "sha512-p0lYA1M7uoEmk2LnCbZLGmHJHyH59sAaZVXChTXlyhV/PRW9LoIh4mdf7tiXsO8BoNG+vN8UnFJff1hbZeXv+w==",
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^8.0.0",
+        "@testing-library/dom": "^8.5.0",
         "@types/react-dom": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.3",
-    "@testing-library/react": "^12.1.4",
+    "@testing-library/react": "^13.0.0",
     "@testing-library/user-event": "^14.0.4",
     "@types/jest": "^27.4.1",
     "@types/node": "^17.0.23",


### PR DESCRIPTION
Check the build logs to make sure the warnings about `render` are gone.